### PR TITLE
Retarget for .net 7

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         build-configuration: [ Debug, Release ]
-        test-target-framework: [ net6.0, net5.0, netcoreapp3.1 ]
+        test-target-framework: [ net7.0, net6.0 ]
     name: Build And Test (${{ matrix.test-target-framework }}, ${{ matrix.build-configuration }})
     runs-on: ubuntu-latest
     steps:
@@ -20,9 +20,8 @@ jobs:
         uses: actions/setup-dotnet@v2
         with:
           dotnet-version: |
+            7.x
             6.x
-            5.x
-            3.1.x
       - name: Restore
         run: dotnet restore ${{ env.JsonDiffPatchSolutionPath }}
       - name: Build

--- a/.gitignore
+++ b/.gitignore
@@ -351,3 +351,4 @@ MigrationBackup/
 
 # Rider
 .idea/
+.DS_Store

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/SystemTextJson.JsonDiffPatch.MSTest/SystemTextJson.JsonDiffPatch.MSTest.csproj
+++ b/src/SystemTextJson.JsonDiffPatch.MSTest/SystemTextJson.JsonDiffPatch.MSTest.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
   </ItemGroup>
 
 </Project>

--- a/src/SystemTextJson.JsonDiffPatch.NUnit/SystemTextJson.JsonDiffPatch.NUnit.csproj
+++ b/src/SystemTextJson.JsonDiffPatch.NUnit/SystemTextJson.JsonDiffPatch.NUnit.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
   </ItemGroup>
 
 </Project>

--- a/src/SystemTextJson.JsonDiffPatch.Xunit/SystemTextJson.JsonDiffPatch.Xunit.csproj
+++ b/src/SystemTextJson.JsonDiffPatch.Xunit/SystemTextJson.JsonDiffPatch.Xunit.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.assert" Version="2.4.1" />
+    <PackageReference Include="xunit.assert" Version="2.4.2" />
   </ItemGroup>
   
 </Project>

--- a/src/SystemTextJson.JsonDiffPatch/SystemTextJson.JsonDiffPatch.csproj
+++ b/src/SystemTextJson.JsonDiffPatch/SystemTextJson.JsonDiffPatch.csproj
@@ -11,11 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="System.Web" Condition="'$(TargetFramework)' == 'net461'" />
+    <Reference Include="System.Web" Condition="'$(TargetFramework)' == 'net462'" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="6.0.0" />
+    <PackageReference Include="System.Text.Json" Version="7.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/SystemTextJson.JsonDiffPatch.Benchmark/SystemTextJson.JsonDiffPatch.Benchmark.csproj
+++ b/test/SystemTextJson.JsonDiffPatch.Benchmark/SystemTextJson.JsonDiffPatch.Benchmark.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net48</TargetFrameworks>
     <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
     <PackageReference Include="JsonDiffPatch.Net" Version="2.3.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/SystemTextJson.JsonDiffPatch.MSTest.Tests/SystemTextJson.JsonDiffPatch.MSTest.Tests.csproj
+++ b/test/SystemTextJson.JsonDiffPatch.MSTest.Tests/SystemTextJson.JsonDiffPatch.MSTest.Tests.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net461;net48</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net462;net48</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
-    <PackageReference Include="coverlet.collector" Version="3.0.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/SystemTextJson.JsonDiffPatch.NUnit.Tests/SystemTextJson.JsonDiffPatch.NUnit.Tests.csproj
+++ b/test/SystemTextJson.JsonDiffPatch.NUnit.Tests/SystemTextJson.JsonDiffPatch.NUnit.Tests.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net461;net48</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net462;net48</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="NUnit" Version="3.13.2"/>
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0"/>
-    <PackageReference Include="coverlet.collector" Version="3.0.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/SystemTextJson.JsonDiffPatch.UnitTests/SystemTextJson.JsonDiffPatch.UnitTests.csproj
+++ b/test/SystemTextJson.JsonDiffPatch.UnitTests/SystemTextJson.JsonDiffPatch.UnitTests.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net461;net48</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net462;net48</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/SystemTextJson.JsonDiffPatch.Xunit.Tests/SystemTextJson.JsonDiffPatch.Xunit.Tests.csproj
+++ b/test/SystemTextJson.JsonDiffPatch.Xunit.Tests/SystemTextJson.JsonDiffPatch.Xunit.Tests.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net461;net48</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net462;net48</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Retain net6.0 for those on LTS release
Remove .net 5 and netcoreapp 3.1
Change net461 to net462 and drop netstandard2.1
Also upgrades third party dependencies - inc. Test frameworks

Addresses: #32 