### PR TITLE
Correct index passed to DiffInternal for modification detection in LS…

### DIFF
--- a/src/SystemTextJson.JsonDiffPatch/Diffs/JsonDiffPatcher.Array.cs
+++ b/src/SystemTextJson.JsonDiffPatch/Diffs/JsonDiffPatcher.Array.cs
@@ -121,7 +121,7 @@ namespace System.Text.Json.JsonDiffPatch
 
                         // We have two objects equal by position or other criteria
                         var itemDiff = new JsonDiffDelta();
-                        DiffInternal(ref itemDiff, left[entry.LeftIndex], right[entry.RightIndex], options);
+                        DiffInternal(ref itemDiff, left[commonHead + entry.LeftIndex], right[commonHead + entry.RightIndex], options);
                         if (itemDiff.Document is not null)
                         {
                             delta.ArrayChange(i, false, itemDiff);


### PR DESCRIPTION
Noticed that  the diff of arrays was not always correct when items were removed, modified and added.
The modifications where not identified.

**example:**
Lets assume I want to diff the following
``
{
  "id": "644fe678c3541f5485b760d2",
  "myArray": [
    {
      "id": "644fe6b2c3541f5485b7639f",
      "comment": "bogus"
    },
    {
      "id": "65fa21a122020709ac83b0ca",
      "comment": "willberemoved"
    },
    {
      "id": "644febdbc3541f5485b79026",
      "comment": "foobar"
    },
    {
      "id": "645001bfc3541f5485b7e189",
      "comment": "example"
    },
    {
      "id": "645003fac3541f5485b7f2ab",
      "comment": "ok"
    }
  ]
}
``
with 
``
{
  "id": "644fe678c3541f5485b760d2",
  "myArray": [
    {
      "id": "644fe6b2c3541f5485b7639f",
      "comment": "bogus"
    },
    {
      "id": "644febdbc3541f5485b79026",
      "comment": "foobar"
    },
    {
      "id": "645001bfc3541f5485b7e189",
      "comment": "example adapted"
    },
    {
      "id": "645003fac3541f5485b7f2ab",
      "comment": "ok"
    },
    {
      "id": "myid",
      "comment": "isadded"
    },
    {
      "id": "myid2",
      "comment": "isadded2"
    }
``
[example, example modified] modification is not found by the diff (delta format).
After some investigation it seems to just pass the wrong index to the DiffInternal in the LCS when checking for modifications in the right side.

After the modification the delta includes the modification as well.